### PR TITLE
Spaces in asset names

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -133,7 +133,7 @@ function getColors() {
               </h1>
               <hr/>
               <p>Here are the Colors and Character Styles defined in the Assets of your project.</p>
-              <textarea id="resources" readonly="true" value='` + colors + `' height=400></textarea>
+              <textarea id="resources" readonly="true" height=400>` + colors + `</textarea>
               <hr/>
               <p>You can manually copy the resources you need from the text area above, or just hit Copy button below to copy all resources to the clipboard.</p>
               <hr/>            

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,10 @@ const { alert, error } = require("./lib/dialogs.js");
 const shell = require("uxp").shell;
 var {Rectangle, Color} = require("scenegraph");
 
+function replaceSpaces(string) {
+  return string.replace(/ /g,"");
+}
+
 function convertTo(format, color) {
     if(format == 'hex')
     {
@@ -51,7 +55,8 @@ function getCharacterAssets()
   for (var i = 0; i < allStyles.length; i++)
   {
     // get style name or create one
-    let styleName = (allStyles[i]['name'] == undefined) ? "Style" + i : allStyles[i]['name'];
+    var styleName = (allStyles[i]['name'] == undefined) ? "Style" + i : allStyles[i]['name'];
+    styleName = replaceSpaces(styleName);
 
     // get the style information
     let charStyle = allStyles[i]['style'];
@@ -83,7 +88,8 @@ function getColors() {
       let newColor = convertTo('hex', allColors[i]['color']['value']);
 
       // get color name or create one
-      let colorName = (allColors[i]['name'] == undefined) ? "Color" + i : allColors[i]['name'];
+      var colorName = (allColors[i]['name'] == undefined) ? "Color" + i : allColors[i]['name'];
+      colorName = replaceSpaces(colorName);
 
       // create resource string
       colors += "<Color x:Key=\"" + colorName + "\">" + newColor + "</Color>\r\n";


### PR DESCRIPTION
Fixes issue #1 all spaces in asset names are removed

Also fixes issues #6 and issue #7 by moving the value to the inner text of the html for text area, I realise this is fixed by other PRs in the same way, however it needed to be fixed to implement this feature.